### PR TITLE
changed to host and bumped build no

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,14 +14,13 @@ source:
   '{{ hash_type }}': '{{ hash_value }}'
 
 build:
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
   noarch: python
 
 requirements:
-  build:
+  host:
     - python
-    - setuptools
     - pip
   run:
     - python >=3,<3.7


### PR DESCRIPTION
This PR updates the recipe to use `host` instead of `build`. The build number was bumped up.